### PR TITLE
Add rexml dependency to fix ruby-head builds

### DIFF
--- a/tomo-plugin-rollbar.gemspec
+++ b/tomo-plugin-rollbar.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-ci", "~> 3.4"
   spec.add_development_dependency "minitest-reporters", "~> 1.3"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rexml", "~> 3.2"
   spec.add_development_dependency "rubocop", "0.78.0"
   spec.add_development_dependency "rubocop-performance", "1.5.2"
   spec.add_development_dependency "webmock", "~> 3.6"


### PR DESCRIPTION
The rexml library is no longer bundled with ruby in ruby-head; it will be distributed as a separate gem. The crack gem, used by webmock, uses rexml but has not been updated to reflect the rexml dependency.

Until crack is updated, work around this issue by explicitly adding the rexml dependency to this project.

Fixes this error:

```
$ bundle exec rake
File does not exist: rexml/parsers/streamparser
rake aborted!
```