### PR TITLE
Reorganize and update boilerplate to latest recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /coverage/
 /doc/
 /pkg/
+/site/
 /spec/reports/
 /tmp/
 /Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-performance
+require:
+  - rubocop-minitest
+  - rubocop-performance
 
 AllCops:
   DisplayCopNames: true
@@ -8,10 +10,6 @@ AllCops:
     - "tmp/**/*"
     - "vendor/**/*"
 
-Layout/LineLength:
-  Exclude:
-    - "*.gemspec"
-
 Layout/HashAlignment:
   EnforcedColonStyle:
     - table
@@ -19,6 +17,10 @@ Layout/HashAlignment:
   EnforcedHashRocketStyle:
     - table
     - key
+
+Layout/LineLength:
+  Exclude:
+    - "*.gemspec"
 
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
@@ -30,7 +32,7 @@ Lint/StructNewOverride:
   Enabled: true
 
 Metrics/AbcSize:
-  Max: 16
+  Max: 20
   Exclude:
     - "test/**/*"
 
@@ -44,8 +46,12 @@ Metrics/ClassLength:
     - "test/**/*"
 
 Metrics/MethodLength:
+  Max: 18
   Exclude:
     - "test/**/*"
+
+Metrics/ParameterLists:
+  Max: 6
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
@@ -68,6 +74,9 @@ Style/DoubleNegation:
 Style/EmptyMethod:
   Enabled: false
 
+Style/FormatStringToken:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 
@@ -82,6 +91,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Style/NumericPredicate:
+  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/README.md
+++ b/README.md
@@ -2,10 +2,21 @@
 
 [![Gem Version](https://badge.fury.io/rb/tomo-plugin-rollbar.svg)](https://rubygems.org/gems/tomo-plugin-rollbar)
 [![Travis](https://img.shields.io/travis/mattbrictson/tomo-plugin-rollbar.svg?label=travis)](https://travis-ci.org/mattbrictson/tomo-plugin-rollbar)
-[![Circle](https://circleci.com/gh/mattbrictson/tomo-plugin-rollbar.svg?style=shield)](https://circleci.com/gh/mattbrictson/tomo-plugin-rollbar)
+[![Circle](https://circleci.com/gh/mattbrictson/tomo-plugin-rollbar.svg?style=shield)](https://app.circleci.com/pipelines/github/mattbrictson/tomo-plugin-rollbar?branch=master)
 [![Code Climate](https://codeclimate.com/github/mattbrictson/tomo-plugin-rollbar/badges/gpa.svg)](https://codeclimate.com/github/mattbrictson/tomo-plugin-rollbar)
 
 This is a [tomo](https://github.com/mattbrictson/tomo) plugin that sends a notification to [Rollbar](https://rollbar.com) on a successful deploy.
+
+---
+
+- [Installation](#installation)
+- [Settings](#settings)
+- [Tasks](#tasks)
+- [Support](#support)
+- [License](#license)
+- [Code of conduct](#code-of-conduct)
+- [Contribution guide](#contribution-guide)
+
 
 ## Installation
 
@@ -53,14 +64,18 @@ Sends an HTTP POST notification to the Rollbar API describing the release that w
 
 Note that this task must run _after_ `git:create_release` in the deploy sequence in order to have access to the release information.
 
-## Contributing
+## Support
 
-Bug reports and pull requests are welcome.
+If you want to report a bug, or have ideas, feedback or questions about the gem, [let me know via GitHub issues](https://github.com/mattbrictson/tomo-plugin-rollbar/issues/new) and I will do my best to provide a helpful answer. Happy hacking!
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the [MIT License](LICENSE.txt).
 
-## Code of Conduct
+## Code of conduct
 
-Everyone interacting in this project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/mattbrictson/tomo-plugin-rollbar/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in this project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](CODE_OF_CONDUCT.md).
+
+## Contribution guide
+
+Pull requests are welcome!

--- a/Rakefile
+++ b/Rakefile
@@ -2,17 +2,21 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"
 
-task default: %i[test rubocop]
-
-RuboCop::RakeTask.new
-
-Rake::TestTask.new("test") do |t|
+Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
+RuboCop::RakeTask.new
+
+task default: %i[test rubocop]
 task bump: %w[bump:bundler bump:ruby bump:year]
+
+Rake::Task["release"].enhance do
+  puts "Don't forget to publish the release on GitHub!"
+  system "open https://github.com/mattbrictson/tomo-plugin-rollbar/releases"
+end
 
 namespace :bump do
   task :bundler do
@@ -29,6 +33,7 @@ namespace :bump do
 
     replace_in_file "tomo-plugin-rollbar.gemspec",
                     /ruby_version = ">= (.*)"/ => lowest
+
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
     replace_in_file ".circleci/config.yml",
                     %r{circleci/ruby:([\d\.]+)} => latest

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+gem "bundler", "~> 2.0"
+require "bundler/setup"
+require "tomo/plugin/rollbar"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/tomo/plugin/rollbar.rb
+++ b/lib/tomo/plugin/rollbar.rb
@@ -2,13 +2,11 @@ require "tomo"
 require_relative "rollbar/tasks"
 require_relative "rollbar/version"
 
-module Tomo::Plugin
-  module Rollbar
-    extend Tomo::PluginDSL
+module Tomo::Plugin::Rollbar
+  extend Tomo::PluginDSL
 
-    tasks Tomo::Plugin::Rollbar::Tasks
+  tasks Tomo::Plugin::Rollbar::Tasks
 
-    defaults rollbar_env:   nil,
-             rollbar_token: nil
-  end
+  defaults rollbar_env:   nil,
+           rollbar_token: nil
 end

--- a/lib/tomo/plugin/rollbar/version.rb
+++ b/lib/tomo/plugin/rollbar/version.rb
@@ -1,7 +1,8 @@
 module Tomo
   module Plugin
-    module Rollbar
-      VERSION = "0.1.1".freeze
-    end
   end
+end
+
+module Tomo::Plugin::Rollbar
+  VERSION = "0.1.1".freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "tomo/plugin/rollbar"
 require "tomo/testing"
+
 require "minitest/autorun"
 Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |rb| require(rb) }

--- a/test/tomo/plugin/rollbar/tasks_test.rb
+++ b/test/tomo/plugin/rollbar/tasks_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Tomo::Plugin::Rollbar::TasksTest < Minitest::Test
+  def setup
+    @tester = Tomo::Testing::MockPluginTester.new(
+      "rollbar",
+      settings: {
+        rollbar_env: "production",
+        rollbar_token: "ABC123"
+      },
+      release: {
+        deploy_user: "tester",
+        revision: "65eda2149dd5ddb842024f281deef7d5a7f2ca6d"
+      }
+    )
+  end
+
+  def test_notify_deploy_sends_http_post
+    stub_request(:post, "https://api.rollbar.com/api/1/deploy/")
+      .with(body: {
+              local_username: "tester",
+              access_token:   "ABC123",
+              environment:    "production",
+              revision:       "65eda2149dd5ddb842024f281deef7d5a7f2ca6d"
+            })
+    @tester.run_task("rollbar:notify_deploy")
+    assert_nil(@tester.executed_script)
+    assert_match(/Rollbar notification complete/i, @tester.stdout)
+  end
+
+  def test_notify_deploy_raises_on_non_200_http_response
+    stub_request(:post, "https://api.rollbar.com/api/1/deploy/")
+      .to_return(status: 401)
+
+    assert_raises(Tomo::Runtime::TaskAbortedError) do
+      @tester.run_task("rollbar:notify_deploy")
+    end
+  end
+end

--- a/test/tomo/plugin/rollbar_test.rb
+++ b/test/tomo/plugin/rollbar_test.rb
@@ -1,39 +1,7 @@
 require "test_helper"
 
 class Tomo::Plugin::RollbarTest < Minitest::Test
-  def setup
-    @tester = Tomo::Testing::MockPluginTester.new(
-      "rollbar",
-      settings: {
-        rollbar_env: "production",
-        rollbar_token: "ABC123"
-      },
-      release: {
-        deploy_user: "tester",
-        revision: "65eda2149dd5ddb842024f281deef7d5a7f2ca6d"
-      }
-    )
-  end
-
-  def test_notify_deploy_sends_http_post
-    stub_request(:post, "https://api.rollbar.com/api/1/deploy/")
-      .with(body: {
-              local_username: "tester",
-              access_token:   "ABC123",
-              environment:    "production",
-              revision:       "65eda2149dd5ddb842024f281deef7d5a7f2ca6d"
-            })
-    @tester.run_task("rollbar:notify_deploy")
-    assert_nil(@tester.executed_script)
-    assert_match(/Rollbar notification complete/i, @tester.stdout)
-  end
-
-  def test_notify_deploy_raises_on_non_200_http_response
-    stub_request(:post, "https://api.rollbar.com/api/1/deploy/")
-      .to_return(status: 401)
-
-    assert_raises(Tomo::Runtime::TaskAbortedError) do
-      @tester.run_task("rollbar:notify_deploy")
-    end
+  def test_that_it_has_a_version_number
+    refute_nil Tomo::Plugin::Rollbar::VERSION
   end
 end

--- a/tomo-plugin-rollbar.gemspec
+++ b/tomo-plugin-rollbar.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "tomo", "~> 1.0"
+  spec.add_dependency "tomo"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "minitest", "~> 5.11"

--- a/tomo-plugin-rollbar.gemspec
+++ b/tomo-plugin-rollbar.gemspec
@@ -20,17 +20,14 @@ Gem::Specification.new do |spec|
   }
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(docs|test|spec|features)/}) }
-  end
+  spec.files = `git ls-files -z exe lib LICENSE.txt README.md`.split("\x0")
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "tomo"
+  spec.add_dependency "tomo", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "minitest", "~> 5.11"
@@ -39,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rexml", "~> 3.2"
   spec.add_development_dependency "rubocop", "0.81.0"
+  spec.add_development_dependency "rubocop-minitest", "0.8.1"
   spec.add_development_dependency "rubocop-performance", "1.5.2"
   spec.add_development_dependency "webmock", "~> 3.6"
 end


### PR DESCRIPTION
Based on the latest tomo-plugin template:

- Add rubocop-minitest
- Loosen up rubocop guidelines
- Point to new CircleCI pipelines UI
- Add TOC, and support section to the README
- Add `bin/console` and `bin/setup` scripts
- Declare `Tomo::Plugin::Rollbar` instead of using nested module syntax
- Move task tests into `rollbar/tasks_test.rb`
