### PR TITLE
Require tomo ~> 1.0

### DIFF
--- a/tomo-plugin-rollbar.gemspec
+++ b/tomo-plugin-rollbar.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "tomo"
+  spec.add_dependency "tomo", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "minitest", "~> 5.11"


### PR DESCRIPTION
Now that tomo 1.0 has been released, pin the tomo dependency so that we don't have to support pre-1.0 compatibility.