### PR TITLE
Adopt latest Gemfile and .gemspec standards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,12 @@
 source "https://rubygems.org"
-
-# Specify your gem's dependencies in tomo-plugin-rollbar.gemspec
 gemspec
+
+gem "minitest", "~> 5.11"
+gem "minitest-ci", "~> 3.4"
+gem "minitest-reporters", "~> 1.3"
+gem "rake", "~> 13.0"
+gem "rexml", "~> 3.2"
+gem "rubocop", "0.86.0"
+gem "rubocop-minitest", "0.9.0"
+gem "rubocop-performance", "1.6.1"
+gem "webmock", "~> 3.6"

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ namespace :bump do
     lowest_minor = RubyVersions.lowest_supported_minor
     latest = RubyVersions.latest
 
-    replace_in_file "tomo-plugin-rollbar.gemspec", /ruby_version = ">= (.*)"/ => lowest
+    replace_in_file "tomo-plugin-rollbar.gemspec", /ruby_version = .*">= (.*)"/ => lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
     replace_in_file ".circleci/config.yml", %r{circleci/ruby:([\d.]+)} => latest
     replace_in_file ".circleci/config.yml", /bundle-.*ruby([\d.]+)-/ => latest
@@ -54,6 +54,8 @@ def replace_in_file(path, replacements)
   contents = IO.read(path)
   orig_contents = contents.dup
   replacements.each do |regexp, text|
+    raise "Can't find #{regexp} in #{path}" unless regexp.match?(contents)
+
     contents.gsub!(regexp) do |match|
       match[regexp, 1] = text
       match

--- a/tomo-plugin-rollbar.gemspec
+++ b/tomo-plugin-rollbar.gemspec
@@ -1,42 +1,28 @@
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "tomo/plugin/rollbar/version"
+require_relative "lib/tomo/plugin/rollbar/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "tomo-plugin-rollbar"
-  spec.version       = Tomo::Plugin::Rollbar::VERSION
-  spec.authors       = ["Matt Brictson"]
-  spec.email         = ["opensource@mattbrictson.com"]
+  spec.name = "tomo-plugin-rollbar"
+  spec.version = Tomo::Plugin::Rollbar::VERSION
+  spec.authors = ["Matt Brictson"]
+  spec.email = ["opensource@mattbrictson.com"]
 
-  spec.summary       = "Provides rollbar tasks for tomo"
-  spec.homepage      = "https://github.com/mattbrictson/tomo-plugin-rollbar"
-  spec.license       = "MIT"
+  spec.summary = "Provides rollbar tasks for tomo"
+  spec.homepage = "https://github.com/mattbrictson/tomo-plugin-rollbar"
+  spec.license = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/mattbrictson/tomo-plugin-rollbar/issues",
     "changelog_uri" => "https://github.com/mattbrictson/tomo-plugin-rollbar/releases",
-    "homepage_uri" => "https://github.com/mattbrictson/tomo-plugin-rollbar",
+    "homepage_uri" => spec.homepage,
     "source_code_uri" => "https://github.com/mattbrictson/tomo-plugin-rollbar"
   }
 
   # Specify which files should be added to the gem when it is released.
   spec.files = `git ls-files -z exe lib LICENSE.txt README.md`.split("\x0")
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5.0"
-
   spec.add_dependency "tomo", "~> 1.0"
-
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "minitest", "~> 5.11"
-  spec.add_development_dependency "minitest-ci", "~> 3.4"
-  spec.add_development_dependency "minitest-reporters", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rexml", "~> 3.2"
-  spec.add_development_dependency "rubocop", "0.86.0"
-  spec.add_development_dependency "rubocop-minitest", "0.9.0"
-  spec.add_development_dependency "rubocop-performance", "1.6.1"
-  spec.add_development_dependency "webmock", "~> 3.6"
 end


### PR DESCRIPTION
- Place development dependencies in the `Gemfile`, not the `.gemspec`
- Do not modify the `$LOAD_PATH` in the `.gemspec`
- Use `Gem::Requirement.new` to specify Ruby requirement
- Do not include `bundler` as a development dependency